### PR TITLE
Parses multiple documents in a stream

### DIFF
--- a/lib/json/stream/parser.rb
+++ b/lib/json/stream/parser.rb
@@ -345,7 +345,22 @@ module JSON
               start_value(ch)
             end
           when :end_document
-            error("Unexpected data") unless ch =~ WS
+            case ch
+            when LEFT_BRACE
+              @state = :start_object
+              @stack.push(:object)
+              notify_start_document
+              notify_start_object
+            when LEFT_BRACKET
+              @state = :start_array
+              @stack.push(:array)
+              notify_start_document
+              notify_start_array
+            when WS
+              # ignore
+            else
+              error("Expected whitespace or object/array start")
+            end
           end
         end
       end

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -120,4 +120,15 @@ class BuilderTest < Test::Unit::TestCase
                 "k5"=>"string value"}
     assert_equal(expected, @b.result)
   end
+
+  def test_two_documents
+    2.times do
+      @b.start_document
+      @b.start_object
+      @b.end_object
+      @b.end_document
+    end
+
+    assert_equal({}, @b.result)
+  end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -5,8 +5,8 @@ require 'test/unit'
 
 class ParserTest < Test::Unit::TestCase
 
-  # JSON documents must start with an array or object container
-  # and there must not be any extra data following that container.
+  # JSON documents must start with an array or object container and there must
+  # not be any extra data following that container unless it is another document
   def test_document
     expected = [:error]
     ['a', 'null', 'false', 'true', '12', '  false  '].each do |json|
@@ -25,6 +25,16 @@ class ParserTest < Test::Unit::TestCase
 
     expected = [:start_document, :start_object, :end_object, :end_document, :error]
     ['{}a', '{ } 12', ' {} false', ' { }, {}'].each do |json|
+      assert_equal(expected, events(json))
+    end
+
+    expected = [:start_document, :start_object, :end_object, :end_document] * 2
+    ['{}{}', '{ } {}', ' {} { }', ' { } { } '].each do |json|
+      assert_equal(expected, events(json))
+    end
+
+    expected = [:start_document, :start_array, :end_array, :end_document] * 2
+    ['[][]', '[ ] []', ' [] [ ]', ' [ ] [ ] '].each do |json|
       assert_equal(expected, events(json))
     end
   end


### PR DESCRIPTION
Thank you for publishing this gem! It's the closest replacement to yajl-ruby for me when I'm on JRuby In my use case I needed to be able to parse multiple JSON documents from a stream. This patch allows `JSON::Stream::Parser` to parse one or more sequential documents. I wasn't really sure what to do with `JSON::Stream::Builder` (I'm not using it) so I tested the existing behavior, which simply uses the last document in the stream. Let me know if you're interested in merging this and if you need anything changed first.

Cheers!
