### PR TITLE
ci: Test with Ruby 2.6, 2.7, 3.0, 3.1 and head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,12 +4,20 @@ jobs:
   test:
     name: rake test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - head
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
       - run: |
-          gem install bundler --no-document
-          bundle install
           bundle exec rake test


### PR DESCRIPTION
We need to use ruby/setup-ruby instead of
actions/setup-ruby. actions/setup-ruby is deprecated. It doesn't
support newer Rubies.

See:
https://github.com/actions/setup-ruby/commit/e932e7af67fc4a8fc77bd86b744acd4e42fe3543

We can use bundler-cache to run Bundler and cache the result with
ruby/setup-ruby: https://github.com/ruby/setup-ruby#bundler