### PR TITLE
support for forzen string literals

### DIFF
--- a/lib/json/stream/buffer.rb
+++ b/lib/json/stream/buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSON
   module Stream
     # A character buffer that expects a UTF-8 encoded stream of bytes.
@@ -29,7 +31,7 @@ module JSON
       def <<(data)
         # Avoid state machine for complete UTF-8.
         if @buffer.empty?
-          data.force_encoding(Encoding::UTF_8)
+          (+data).force_encoding(Encoding::UTF_8)
           return data if data.valid_encoding?
         end
 

--- a/lib/json/stream/buffer.rb
+++ b/lib/json/stream/buffer.rb
@@ -31,7 +31,8 @@ module JSON
       def <<(data)
         # Avoid state machine for complete UTF-8.
         if @buffer.empty?
-          (+data).force_encoding(Encoding::UTF_8)
+          data = data.dup
+          data.force_encoding(Encoding::UTF_8)
           return data if data.valid_encoding?
         end
 

--- a/lib/json/stream/parser.rb
+++ b/lib/json/stream/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSON
   module Stream
     # Raised on any invalid JSON text.
@@ -102,8 +104,8 @@ module JSON
 
         # Track parse stack.
         @stack = []
-        @unicode = ""
-        @buf = ""
+        @unicode = +""
+        @buf = +""
         @pos = -1
 
         # Register any observers in the block.
@@ -178,7 +180,7 @@ module JSON
                 @state = :end_key
                 notify(:key, @buf)
               end
-              @buf = ""
+              @buf = +""
             when BACKSLASH
               @state = :start_escape
             when CONTROL
@@ -270,7 +272,7 @@ module JSON
               @buf << ch
             else
               end_value(@buf.to_i)
-              @buf = ""
+              @buf = +""
               @pos -= 1
               redo
             end
@@ -291,7 +293,7 @@ module JSON
               @buf << ch
             else
               end_value(@buf.to_f)
-              @buf = ""
+              @buf = +""
               @pos -= 1
               redo
             end
@@ -310,7 +312,7 @@ module JSON
             else
               error('Expected 0-9 digit') unless @buf =~ DIGIT_END
               end_value(@buf.to_f)
-              @buf = ""
+              @buf = +""
               @pos -= 1
               redo
             end
@@ -326,7 +328,7 @@ module JSON
               @buf << ch
             else
               end_value(@buf.to_i)
-              @buf = ""
+              @buf = +""
               @pos -= 1
               redo
             end
@@ -503,7 +505,7 @@ module JSON
 
         if @buf.size == word.size
           if @buf == word
-            @buf = ""
+            @buf = +""
             end_value(value)
           else
             error("Expected #{word} keyword")


### PR DESCRIPTION
## Issue

When running tests with Ruby 3.4.0rc1, the following warnings are displayed.

```console
$ rake test
Run options: --seed 46514

/work/ruby/json-stream/lib/json/stream/parser.rb:549: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/work/ruby/json-stream/lib/json/stream/parser.rb:555: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

## Causes

According to https://bugs.ruby-lang.org/issues/20205, string literals may be frozen by default in future Ruby versions (potentially Ruby 4.0+).
Starting from Ruby 3.4.0, warnings like `warning: literal string will be frozen in the future` are shown if string literals are mutable.

## Solution

We explicitly make string literals mutable using `+"string literal"` Additionally, we add `# frozen_string_literal: true` at the top of the affected files and handle the warnings to ensure compatibility with Ruby versions before 3.4.0.